### PR TITLE
Create missing tables

### DIFF
--- a/nodes/node_duplicator.lua
+++ b/nodes/node_duplicator.lua
@@ -146,6 +146,9 @@ minetest.register_node("digtron:duplicator", {
 			-- clear inventories of image's nodes			
 			for _, node_image in pairs(layout.inventories) do
 				local main_inventory = node_image.meta.inventory.main
+				if type(main_inventory) ~= "table" then
+					main_inventory = {}
+				end
 				for index, _ in pairs(main_inventory) do
 					main_inventory[index] = ItemStack(nil)
 				end

--- a/nodes/node_item_ejector.lua
+++ b/nodes/node_item_ejector.lua
@@ -67,6 +67,9 @@ local function eject_items(pos, node, player, eject_even_without_pipeworks)
 	local source_index = nil
 	local source_stack = nil
 	for _, node_image in pairs(layout.inventories) do
+		if type(node_image.meta.inventory.main) ~= "table" then
+			node_image.meta.inventory.main = {}
+		end
 		for index, item_stack in pairs(node_image.meta.inventory.main) do
 			if item_stack:get_count() > 0 and not filter_items[item_stack:get_name()] then
 				source_node = node_image


### PR DESCRIPTION
After a failure to move the digtron with its metadata, some nodes were
broken. This worked around crashes that occurred if the inventory table
was missing.