### PR TITLE
Add missing items_dropped parameter 

### DIFF
--- a/util_execute_cycle.lua
+++ b/util_execute_cycle.lua
@@ -532,7 +532,7 @@ digtron.execute_downward_dig_cycle = function(pos, clicker)
 			local target = minetest.get_node(location.pos)
 			local targetdef = minetest.registered_nodes[target.name]
 			if targetdef.damage_creatures ~= nil then
-				targetdef.damage_creatures(clicker, location.pos, controlling_coordinate)
+				targetdef.damage_creatures(clicker, location.pos, controlling_coordinate, items_dropped)
 			end
 		end
 	end


### PR DESCRIPTION
This was probably forgotten in 5c0700456c09d2f5276572392d1c4e13b4b4d757
Fixes a crash encountered when damaging creatures while digging downward.