### PR TITLE
Avoid crate corruption when dug with special tools

### DIFF
--- a/nodes/node_crate.lua
+++ b/nodes/node_crate.lua
@@ -309,7 +309,7 @@ minetest.register_node("digtron:loaded_crate", {
 
 	on_dig = function(pos, node, player)
 		if player and not minetest.is_protected(pos, player:get_player_name()) then
-			loaded_on_dig(pos, player, "digtron:loaded_crate")
+			return loaded_on_dig(pos, player, "digtron:loaded_crate")
 		end
 	end,
 	


### PR DESCRIPTION
A missing return in on_dig callback for digtron:loaded_crate, makes crate corrupted if dug with certain tools, in particular technics drills.