### PR TITLE
Update layout to prevent duplication during ejection

### DIFF
--- a/nodes/node_item_ejector.lua
+++ b/nodes/node_item_ejector.lua
@@ -79,6 +79,7 @@ local function eject_items(pos, node, player, eject_even_without_pipeworks, layo
 				source_node = node_image
 				source_index = index
 				source_stack = item_stack
+				node_image.meta.inventory.main[index] = nil
 				break
 			end
 		end


### PR DESCRIPTION
Items can be duplicated by using multiple ejectors with one inventory.
One-liner fix, urgent I suppose.