### PR TITLE
Fix and simplify battery usage

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -256,28 +256,12 @@ digtron.tap_batteries = function(battery_positions, target, test)
 				local power_available = math.floor(meta.charge / digtron.config.power_ratio)
 				if power_available ~= 0 then
 					local actual_burned = power_available -- we just take all we have from the battery, since they aren't stackable
+					-- don't bother recording the items if we're just testing, nothing is actually being removed.
 					if test ~= true then
-						-- don't bother recording the items if we're just testing, nothing is actually being removed.
-						local charge_left = meta.charge - power_available * digtron.config.power_ratio
-						local properties = itemstack:get_tool_capabilities()
-						-- itemstack = technic.set_RE_wear(itemstack, charge_left, properties.groupcaps.fleshy.uses)
-						-- we only need half the function, so why bother using it in the first place
-
-						-- Charge is stored separately, but shown as wear level
-						-- This calls for recalculating the value.
-						local charge_level
-						if charge_left == 0 then
-							charge_level = 0
-						else
-							charge_level = 65536 - math.floor(charge_left / properties.groupcaps.fleshy.uses * 65535)
-							if charge_level > 65535 then charge_level = 65535 end
-							if charge_level < 1 then charge_level = 1 end
-						end
-						itemstack:set_wear(charge_level)
-						
-						meta.charge = charge_left
+						-- since we are taking everything, the wear and charge can both be set to 0
+						itemstack:set_wear(0)
+						meta.charge = 0
 						itemstack:set_metadata(minetest.serialize(meta))
-
 					end
 					current_burned = current_burned + actual_burned
 				end


### PR DESCRIPTION
Changes `digtron.tap_batteries` function so that battery wear and charge is set directly to 0 instead of needlessly calculating it.

Fixes a crash that happens if a battery item doesn't define tool capabilities:
```
2020-03-07 13:44:30: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod '' in callback node_on_receive_fields(): /data/world//worldmods/digtron/util.lua:272: attempt to index field 'fleshy' (a nil value)
2020-03-07 13:44:30: ERROR[Main]: stack traceback:
2020-03-07 13:44:30: ERROR[Main]: 	/data/world//worldmods/digtron/util.lua:272: in function 'tap_batteries'
2020-03-07 13:44:30: ERROR[Main]: 	/data/world//worldmods/digtron/util_execute_cycle.lua:376: in function 'f'
2020-03-07 13:44:30: ERROR[Main]: 	.../worldmods/monitoring/monitoring/metrictypes/counter.lua:45: in function 'execute_dig_cycle'
2020-03-07 13:44:30: ERROR[Main]: 	/data/world//worldmods/digtron/nodes/node_controllers.lua:148: in function 'auto_cycle'
2020-03-07 13:44:30: ERROR[Main]: 	/data/world//worldmods/digtron/nodes/node_controllers.lua:264: in function </data/world//worldmods/digtron/nodes/node_controllers.lua:238>
```

Fixes https://github.com/pandorabox-io/pandorabox.io/issues/462