### PR TITLE
Change `after_dig_node()` callbacks to supply metadata as table.

### DIFF
--- a/class_layout.lua
+++ b/class_layout.lua
@@ -457,7 +457,7 @@ function DigtronLayout.write_layout_image(self, player)
 	local oldpos, _ = self.old_pos_pointset:pop()
 	while oldpos ~= nil do
 		local old_node = minetest.get_node(oldpos)
-		local old_meta = minetest.get_meta(oldpos)
+		local old_meta = minetest.get_meta(oldpos):to_table()
 
 		if not set_node_with_retry(oldpos, air_node) then
 			minetest.log("error", "DigtronLayout.write_layout_image failed to destroy old Digtron node, aborting write.")


### PR DESCRIPTION
Metadata was previously lost according to my testing.
Now, the behaviour will be as specified in Minetest's lua_api.txt.

See https://github.com/minetest/minetest/blob/4b4513a67d9fc426d0f33798d0810a3a0594baaf/doc/lua_api.txt#L7315-L7316