### PR TITLE
auto_controller: Avoid nil error when digging slopes

### DIFF
--- a/nodes/node_controllers.lua
+++ b/nodes/node_controllers.lua
@@ -270,6 +270,7 @@ minetest.register_node("digtron:auto_controller", {
 			local node = minetest.get_node(pos)
 			local controlling_coordinate = digtron.get_controlling_coordinate(pos, node.param2)
 			
+			offset = offset or 0
 			local newpos = pos
 			local markerpos = {x=newpos.x, y=newpos.y, z=newpos.z}
 			local x_pos = math.floor((newpos[controlling_coordinate]+offset)/slope)*slope - offset


### PR DESCRIPTION
Crashes otherwise on MT 5.3.0 if offset field is left empty.
Related: https://github.com/minetest/minetest/issues/10180