### PR TITLE
Fix use_texture_alpha warnings.

### DIFF
--- a/nodes/node_controllers.lua
+++ b/nodes/node_controllers.lua
@@ -17,6 +17,8 @@ local controller_nodebox ={
 
 local node_inventory_table = {type="node"} -- a reusable parameter for get_inventory calls, set the pos parameter before using.
 
+local use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "opaque" or nil
+
 -- Master controller. Most complicated part of the whole system. Determines which direction a digtron moves and triggers all of its component parts.
 minetest.register_node("digtron:controller", {
 	description = S("Digtron Control Module"),
@@ -184,6 +186,7 @@ minetest.register_node("digtron:auto_controller", {
 	groups = {cracky = 3, oddly_breakable_by_hand = 3, digtron = 1},
 	drop = "digtron:auto_controller",
 	sounds = digtron.metal_sounds,
+	use_texture_alpha = use_texture_alpha,
 	paramtype = "light",
 	paramtype2= "facedir",
 	is_ground_content = false,
@@ -310,6 +313,7 @@ minetest.register_node("digtron:pusher", {
 	groups = {cracky = 3, oddly_breakable_by_hand=3, digtron = 1},
 	drop = "digtron:pusher",
 	sounds = digtron.metal_sounds,
+	use_texture_alpha = use_texture_alpha,
 	paramtype = "light",
 	paramtype2= "facedir",
 	is_ground_content = false,

--- a/nodes/node_crate.lua
+++ b/nodes/node_crate.lua
@@ -88,6 +88,8 @@ local store_digtron = function(pos, clicker, loaded_node_name, protected)
 	meta:set_string("infotext", titlestring .. "\n" .. protection_suffix)
 end
 
+local use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "opaque" or nil
+
 minetest.register_node("digtron:empty_crate", {
 	description = S("Digtron Crate (Empty)"),
 	_doc_items_longdesc = digtron.doc.empty_crate_longdesc,
@@ -95,6 +97,7 @@ minetest.register_node("digtron:empty_crate", {
 	groups = {cracky = 3, oddly_breakable_by_hand=3},
 	sounds = default.node_sound_wood_defaults(),
 	tiles = {"digtron_crate.png"},
+	use_texture_alpha = use_texture_alpha,
 	is_ground_content = false,
 	drawtype = "nodebox",
 	node_box = {
@@ -121,6 +124,7 @@ minetest.register_node("digtron:empty_locked_crate", {
 	groups = {cracky = 3, oddly_breakable_by_hand=3},
 	sounds = default.node_sound_wood_defaults(),
 	tiles = {"digtron_crate.png","digtron_crate.png","digtron_crate.png^digtron_lock.png","digtron_crate.png^digtron_lock.png","digtron_crate.png^digtron_lock.png","digtron_crate.png^digtron_lock.png"},
+	use_texture_alpha = use_texture_alpha,
 	is_ground_content = false,
 	drawtype = "nodebox",
 	node_box = {

--- a/nodes/node_diggers.lua
+++ b/nodes/node_diggers.lua
@@ -75,6 +75,8 @@ local intermittent_on_rightclick = function(pos, node, clicker, itemstack, point
 		intermittent_formspec(pos, meta))
 end
 
+local use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "opaque" or nil
+
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if formname:sub(1, 27) == "digtron:intermittent_digger" then
 		local pos = minetest.string_to_pos(formname:sub(28, -1))
@@ -231,6 +233,7 @@ minetest.register_node("digtron:soft_digger", {
 	groups = {cracky = 3,  oddly_breakable_by_hand=3, digtron = 3},
 	drop = "digtron:soft_digger",
 	sounds = digtron.metal_sounds,
+	use_texture_alpha = use_texture_alpha,
 	paramtype = "light",
 	paramtype2= "facedir",
 	is_ground_content = false,
@@ -287,6 +290,7 @@ minetest.register_node("digtron:intermittent_soft_digger", {
 	groups = {cracky = 3,  oddly_breakable_by_hand=3, digtron = 3},
 	drop = "digtron:intermittent_soft_digger",
 	sounds = digtron.metal_sounds,
+	use_texture_alpha = use_texture_alpha,
 	paramtype = "light",
 	paramtype2= "facedir",
 	is_ground_content = false,
@@ -441,6 +445,7 @@ minetest.register_node("digtron:dual_soft_digger", {
 	groups = {cracky = 3,  oddly_breakable_by_hand=3, digtron = 3},
 	drop = "digtron:dual_soft_digger",
 	sounds = digtron.metal_sounds,
+	use_texture_alpha = use_texture_alpha,
 	paramtype = "light",
 	paramtype2= "facedir",
 	is_ground_content = false,	


### PR DESCRIPTION
Eliminate warnings with use_texture_alpha in node definition in newer versions of minetest clients.