### PR TITLE
Node diggers also eating dungeon chests

### DIFF
--- a/nodes/node_diggers.lua
+++ b/nodes/node_diggers.lua
@@ -147,6 +147,27 @@ minetest.register_node("digtron:digger", {
 			return 0
 		end
 
+		local dignode = minetest.get_node(digpos)
+
+		-- default:chest are common in underground dungeons
+		-- Avoid them interrupting the automation by absorbing all the items in them.
+		if dignode.name == "default:chest" or dignode.name == "default:chest_open" then
+			local inv = minetest.get_meta(digpos):get_inventory()
+			local list_main = inv:get_list("main")
+			inv:set_list("main", {})
+			local fuel_cost, dropped = digtron.mark_diggable(digpos, nodes_dug, player)
+			if dropped then
+				for _, item in ipairs(list_main) do
+					if not item:is_empty() then
+						table.insert(dropped, item)
+					end
+				end
+
+				return fuel_cost, dropped
+			else
+				inv:set_list("main", list_main)
+			end
+		end
 		return digtron.mark_diggable(digpos, nodes_dug, player)
 	end,
 


### PR DESCRIPTION
`default:chest` is seen in underground dungeons. To keep them from interrupting the automation, this PR adds them to the list of nodes by putting all their contents into the inventory.

And yeah, I did a test too. Here is the footage:

https://github.com/minetest-mods/digtron/assets/55009343/5fe087da-8054-4711-8f81-7f5e84cf4f22

Wait... this may cause performance overhead even if there are no chests due to the additional `minetest.get_node(digpos)` call... IDK if this is a concern tho.

