### PR TITLE
Fix use_texture_alpha warnings

### DIFF
--- a/nodes/node_builders.lua
+++ b/nodes/node_builders.lua
@@ -449,6 +449,7 @@ minetest.register_node("digtron:master_builder", {
 		"digtron_plate.png^digtron_master_builder.png^[colorize:" .. digtron.auto_controller_colorize,
 		"digtron_plate.png^digtron_master_builder.png^[colorize:" .. digtron.auto_controller_colorize,
 	},
+	use_texture_alpha = "opaque",
 
 	drawtype = "nodebox",
 	node_box = {


### PR DESCRIPTION
This PR fixes the `use_texture_alpha` warning on the master builder, the only node involving textures with an alpha channel. As no transparency exists in used pixels, it is set to `"opaque"`.

No news is the good news. See, an ordinary master builder... except this time it is rendered with this PR.
![screenshot_20240117_122346](https://github.com/minetest-mods/digtron/assets/55009343/5214a7ef-d213-4de9-9f82-72866e124f4c)
