### PR TITLE
Fix deprecated function calls

### DIFF
--- a/nodes/node_axle.lua
+++ b/nodes/node_axle.lua
@@ -65,7 +65,7 @@ minetest.register_node("digtron:axle", {
 				minetest.sound_play("whirr", {gain=1.0, pos=pos})
 				meta = minetest.get_meta(pos)
 				meta:set_string("waiting", "true")
-				meta:set_string("infotext", nil)
+				meta:set_string("infotext", "")
 				-- minetest.get_node_timer(pos):start(digtron.config.cycle_time*2)
 				-- new delay code
 				meta:set_string("last_time",tostring(minetest.get_gametime()))
@@ -79,6 +79,6 @@ minetest.register_node("digtron:axle", {
 	end,
 
 	on_timer = function(pos)
-		minetest.get_meta(pos):set_string("waiting", nil)
+		minetest.get_meta(pos):set_string("waiting", "")
 	end,
 })

--- a/nodes/node_controllers.lua
+++ b/nodes/node_controllers.lua
@@ -85,7 +85,7 @@ minetest.register_node("digtron:controller", {
 	end,
 
 	on_timer = function(pos)
-		minetest.get_meta(pos):set_string("waiting", nil)
+		minetest.get_meta(pos):set_string("waiting", "")
 	end,
 })
 
@@ -184,7 +184,7 @@ local function auto_cycle(pos)
 	meta:set_int("cycles", cycle)
 	status = status .. "\n" .. S("Cycles remaining: @1", cycle)
 	meta:set_string("infotext", status)
-	meta:set_string("lateral_done", nil)
+	meta:set_string("lateral_done", "")
 
 	if cycle > 0 then
 		minetest.after(meta:get_int("period"), auto_cycle, newpos)
@@ -278,8 +278,8 @@ minetest.register_node("digtron:auto_controller", {
 			if sender:is_player() and cycles > 0 then
 				meta:set_string("triggering_player", sender:get_player_name())
 				if fields.execute then
-					meta:set_string("waiting", nil)
-					meta:set_string("formspec", nil)
+					meta:set_string("waiting", "")
+					meta:set_string("formspec", "")
 					auto_cycle(pos)
 				end
 			end
@@ -366,6 +366,6 @@ minetest.register_node("digtron:pusher", {
 	end,
 
 	on_timer = function(pos)
-		minetest.get_meta(pos):set_string("waiting", nil)
+		minetest.get_meta(pos):set_string("waiting", "")
 	end,
 })

--- a/util.lua
+++ b/util.lua
@@ -417,14 +417,14 @@ digtron.show_offset_markers = function(pos, offset, period)
 	local z_pos = math.floor((buildpos.z+offset)/period)*period - offset
 
 	local entity = safe_add_entity({x=buildpos.x, y=buildpos.y, z=z_pos}, "digtron:marker")
-	if entity ~= nil then entity:setyaw(1.5708) end
+	if entity ~= nil then entity:set_yaw(1.5708) end
 
 	if z_pos >= buildpos.z then
 		entity = safe_add_entity({x=buildpos.x, y=buildpos.y, z=z_pos - period}, "digtron:marker")
-		if entity ~= nil then entity:setyaw(1.5708) end
+		if entity ~= nil then entity:set_yaw(1.5708) end
 	end
 	if z_pos <= buildpos.z then
 		entity = safe_add_entity({x=buildpos.x, y=buildpos.y, z=z_pos + period}, "digtron:marker")
-		if entity ~= nil then entity:setyaw(1.5708) end
+		if entity ~= nil then entity:set_yaw(1.5708) end
 	end
 end

--- a/util_execute_cycle.lua
+++ b/util_execute_cycle.lua
@@ -102,6 +102,14 @@ local function check_digtron_size(layout)
 	end
 end
 
+local function add_object_pos(object, dir)
+	if object.add_pos then
+		object:add_pos(dir)
+	else
+		object:move_to(vector.add(dir, object:get_pos()), true)
+	end
+end
+
 -- returns newpos, status string, and a return code indicating why the method returned (so the auto-controller can keep trying if it's due to unloaded nodes)
 -- 0 - success
 -- 1 - failed due to unloaded nodes
@@ -324,7 +332,7 @@ digtron.execute_dig_cycle = function(pos, clicker)
 	pos = vector.add(pos, dir)
 	meta = minetest.get_meta(pos)
 	if move_player then
-		clicker:moveto(vector.add(dir, clicker:get_pos()), true)
+		add_object_pos(clicker, dir)
 	end
 
 	-- store or drop the products of the digger heads
@@ -463,7 +471,7 @@ digtron.execute_move_cycle = function(pos, clicker)
 
 	pos = vector.add(pos, dir)
 	if move_player then
-		clicker:moveto(vector.add(clicker:get_pos(), dir), true)
+		add_object_pos(clicker, dir)
 	end
 	return pos, "", 0
 end
@@ -583,7 +591,7 @@ digtron.execute_downward_dig_cycle = function(pos, clicker)
 	pos = vector.add(pos, dir)
 	meta = minetest.get_meta(pos)
 	if move_player then
-		clicker:moveto(vector.add(clicker:get_pos(), dir), true)
+		add_object_pos(clicker, dir)
 	end
 
 	-- store or drop the products of the digger heads

--- a/util_execute_cycle.lua
+++ b/util_execute_cycle.lua
@@ -102,19 +102,18 @@ local function check_digtron_size(layout)
 	end
 end
 
-local function add_object_pos(object, dir)
-	-- Cache the function we use, optimizing second+ calls
-	if object.add_pos then
-		-- For Minetest 5.9 or later
-		add_object_pos = function(f_object, f_dir)
-			f_object:add_pos(f_dir)
-		end
-	else
-		add_object_pos = function(f_object, f_dir)
-			f_object:move_to(vector.add(f_dir, f_object:get_pos()), true)
-		end
+-- add_pos was introduced on Jan5 and this feature on Jan 17
+-- This is the simpliest way to detect the version we need
+-- Since we cannoty access ObjectRef before we get one
+local add_object_pos
+if minetest.features.random_state_restore then
+	add_object_pos = function(object, dir)
+		object:add_pos(dir)
 	end
-	add_object_pos(object, dir)
+else
+	add_object_pos = function(object, dir)
+		object:move_to(vector.add(dir, object:get_pos()), true)
+	end
 end
 
 -- returns newpos, status string, and a return code indicating why the method returned (so the auto-controller can keep trying if it's due to unloaded nodes)

--- a/util_execute_cycle.lua
+++ b/util_execute_cycle.lua
@@ -103,11 +103,18 @@ local function check_digtron_size(layout)
 end
 
 local function add_object_pos(object, dir)
+	-- Cache the function we use, optimizing second+ calls
 	if object.add_pos then
-		object:add_pos(dir)
+		-- For Minetest 5.9 or later
+		add_object_pos = function(f_object, f_dir)
+			f_object:add_pos(f_dir)
+		end
 	else
-		object:move_to(vector.add(dir, object:get_pos()), true)
+		add_object_pos = function(f_object, f_dir)
+			f_object:move_to(vector.add(f_dir, f_object:get_pos()), true)
+		end
 	end
+	add_object_pos(object, dir)
 end
 
 -- returns newpos, status string, and a return code indicating why the method returned (so the auto-controller can keep trying if it's due to unloaded nodes)

--- a/util_execute_cycle.lua
+++ b/util_execute_cycle.lua
@@ -102,7 +102,8 @@ local function check_digtron_size(layout)
 	end
 end
 
--- add_pos was introduced on Jan5 and this feature on Jan 17
+-- :add_pos(...) is available on 2024-01-05 since Minetest 5.9.0-dev, commit d0753ddd
+-- random_state_restore is introduced on 2024-01-17 in commit ceaa7e2
 -- This is the simpliest way to detect the version we need
 -- Since we cannoty access ObjectRef before we get one
 local add_object_pos


### PR DESCRIPTION
This PR relaces deprecated calls. The following are fixed:

* Calls to `ObjectRef:moveto()` (Replaced by `ObjectRef:add_pos()` or `ObjectRef:move_to()` depending on engine version)
* Calls to `ObjectRef:setyaw()` (Replaced by `ObjectRef:set_yaw()`)
* Calling `MetaDataRef:set_string()` with `nil` as the second parameter (Replaced by `""`)

The following one is purposely not fixed:

https://github.com/minetest-mods/digtron/blob/64416fd07c16c7348e7f6481532f05e262644656/nodes/node_crate.lua#L296

This PR is ready for review.