### PR TITLE
Allow moving fuel items in combined storage by shift-clicking

### DIFF
--- a/nodes/node_storage.lua
+++ b/nodes/node_storage.lua
@@ -206,6 +206,8 @@ local combined_storage_formspec_string =
 	"list[current_name;fuel;0,4.1;8,1;]" ..
 	"list[current_player;main;0,5.75;8,1;]" ..
 	"list[current_player;main;0,6.98;8,3;8]" ..
+	"listring[current_name;fuel]" ..
+	"listring[current_player;main]" ..
 	"listring[current_name;main]" ..
 	"listring[current_player;main]" ..
 	default.get_hotbar_bg(0,5.75)


### PR DESCRIPTION
This PR redoes the list ring to allow moving fuel items in combined storage into the player's main storage by shift-clicking. Note that existing storages (both in-world and in-crate) are not updated.

This PR is ready for review.