### PR TITLE
Add unknown node definition fallback where needed

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,7 +6,8 @@ globals = {
 }
 
 read_globals = {
-	-- Minetest
+	-- Luanti/Minetest
+	"core",
 	"minetest",
 	"vector",
 	"ItemStack",

--- a/class_layout.lua
+++ b/class_layout.lua
@@ -6,7 +6,7 @@ digtron.DigtronLayout.__index = digtron.DigtronLayout
 
 local get_node_image = function(pos, node)
 	local node_image = {node=node, pos={x=pos.x, y=pos.y, z=pos.z}}
-	local node_def = minetest.registered_nodes[node.name]
+	local node_def = digtron.get_nodedef(node.name)
 	node_image.paramtype2 = node_def.paramtype2
 	local meta = minetest.get_meta(pos)
 	node_image.meta = meta:to_table()
@@ -167,7 +167,7 @@ function digtron.DigtronLayout.create(pos, player)
 			to_test:set_if_not_in(tested, testpos.x, testpos.y - 1, testpos.z, true)
 			to_test:set_if_not_in(tested, testpos.x, testpos.y, testpos.z + 1, true)
 			to_test:set_if_not_in(tested, testpos.x, testpos.y, testpos.z - 1, true)
-		elseif not minetest.registered_nodes[node.name] or minetest.registered_nodes[node.name].buildable_to ~= true then
+		elseif not digtron.get_nodedef(node.name).buildable_to then
 			-- Tracks whether the digtron is hovering in mid-air. If any part of the digtron array touches something solid it gains traction.
 			-- Allowing unknown nodes to provide traction, since they're not buildable_to either
 			self.traction = self.traction + 1
@@ -364,7 +364,7 @@ function digtron.DigtronLayout.can_write_layout_image(self)
 		-- check if the target node is buildable_to or is marked as part of the digtron that's moving
 		if not (
 			self.old_pos_pointset:get(node_image.pos.x, node_image.pos.y, node_image.pos.z)
-			or minetest.registered_nodes[minetest.get_node(node_image.pos).name].buildable_to
+			or digtron.get_nodedef(core.get_node(node_image.pos).name).buildable_to
 			) then
 			return false
 		end

--- a/nodes/node_crate.lua
+++ b/nodes/node_crate.lua
@@ -238,7 +238,7 @@ local loaded_on_recieve = function(pos, fields, sender, protected)
 			if minetest.is_protected(node_image.pos, sender:get_player_name()) and not minetest.check_player_privs(sender, "protection_bypass") then
 				protected_node = true
 				minetest.add_entity(node_image.pos, "digtron:marker_crate_bad")
-			elseif not minetest.registered_nodes[minetest.get_node(node_image.pos).name].buildable_to then
+			elseif not digtron.get_nodedef(core.get_node(node_image.pos).name).buildable_to then
 				obstructed_node = true
 				minetest.add_entity(node_image.pos, "digtron:marker_crate_bad")
 			else

--- a/nodes/node_duplicator.lua
+++ b/nodes/node_duplicator.lua
@@ -150,7 +150,7 @@ minetest.register_node("digtron:duplicator", {
 			local unsatisfied = {}
 			for name, count in pairs(required_count) do
 				if not inv:contains_item("main", ItemStack({name=name, count=count})) then
-					table.insert(unsatisfied, tostring(count) .. " " .. minetest.registered_nodes[name].description)
+					table.insert(unsatisfied, tostring(count) .. " " .. digtron.get_nodedef(name).description)
 				end
 			end
 			if #unsatisfied > 0 then

--- a/util.lua
+++ b/util.lua
@@ -35,6 +35,17 @@ digtron.find_new_pos_downward = function(pos, facing)
 	return vector.add(pos, digtron.facedir_to_down_dir(facing))
 end
 
+local registered_nodes = core.registered_nodes
+local unknown_node_def_fallback = {
+	-- for node_duplicator.lua / on_receive_fields
+	description = "unknown node",
+	-- for class_layout.lua / get_node_image
+	paramtype2 = "none",
+}
+digtron.get_nodedef = function(name)
+	return registered_nodes[name] or unknown_node_def_fallback
+end
+
 digtron.mark_diggable = function(pos, nodes_dug, player)
 	-- mark the node as dug, if the player provided would have been able to dig it.
 	-- Don't *actually* dig the node yet, though, because if we dig a node with sand over it the sand will start falling
@@ -93,7 +104,7 @@ digtron.can_build_to = function(pos, protected_nodes, dug_nodes)
 	local target = minetest.get_node(pos)
 	if target.name == "air" or
 	   dug_nodes:get(pos.x, pos.y, pos.z) == true or
-	   minetest.registered_nodes[target.name].buildable_to == true
+	   digtron.get_nodedef(target.name).buildable_to
 	   then
 		return true
 	end


### PR DESCRIPTION
This fixed errors caused by unknown nodes. core.registered_nodes[name] is nil in that case.

Fixes #112

@Pivert Please let me know whether this fixes your issue and whether there are any other errors that need fixing.